### PR TITLE
Document the event interface

### DIFF
--- a/src/events/Pub.html
+++ b/src/events/Pub.html
@@ -1,0 +1,15 @@
+<section>
+  <h2>respecEvents.pub</h2>
+  <p>
+    A method to publish event.  The event will be delivered to each subscriber.
+  </p>
+  <pre>
+  respecEvents.pub(eventName, message)
+  </pre>
+  <dl>
+      <dt>eventName</dt>
+      <dd>The name of the event to publish.</dd>
+      <dt>message</dt>
+      <dd>A message to send to subscribers about the event.</dd>
+  </dl>
+</section>

--- a/src/events/Sub.html
+++ b/src/events/Sub.html
@@ -1,0 +1,16 @@
+<section>
+  <h2>respecEvents.sub</h2>
+  <p>
+    A method to subscribe to an event.
+  </p>
+  <pre>
+  respecEvents.sub(eventName, handler)
+  </pre>
+  <dl>
+      <dt>eventName</dt>
+      <dd>The name of the event to which to subscribe.</dd>
+      <dt>handler</dt>
+      <dd>A function that will be called when the event is received.  It is passed the "message" from
+      the event as its only parameter.</dd>
+  </dl>
+</section>

--- a/src/events/events.html
+++ b/src/events/events.html
@@ -1,0 +1,28 @@
+<section>
+  <h2>Events</h2>
+  <p>
+    The following events are currently available from ReSpec.
+  </p>
+  <dl>
+      <dt>start-all</dt>
+      <dd>An event fired at the very start of ReSpec processing.</dd>
+      <dt>start</dt>
+      <dd>An event fired at the start of each included plugin.  The message contains the name of the
+      plugin being processed.</dd>
+      <dt>end</dt>
+      <dd>An event fired at the end of each included plugin.  The message contains the name of the
+      plugin for which processing just completed.</dd>
+      <dt>end-all</dt>
+      <dd>An event fired at the very end of ReSpec processing.</dd>
+      <dt>error</dt>
+      <dd>An event fired whenever ReSpec encounters an error while processing.  The message contains
+      the nature of the error.</dd>
+      <dt>warn</dt>
+      <dd>An event fired whenever ReSpec encounters a warning while processing.  The message contains
+      the nature of the warning.</dd>
+      <dt>save</dt>
+      <dd>An event fired at the start of any of the ReSpec save snapshot functions.  The message contains the
+      name of the save type being executed.  Defined save types are "toString" for HTML, "toXML5" for
+      XHTML5, "toXML1" for XHTML 1.0, and "toDiffHTML" for diffmarked HTML.</dd>
+  </dl>
+</section>

--- a/src/index.html
+++ b/src/index.html
@@ -44,7 +44,7 @@
       </p>
       <p>
         The <strong><a href='ref.html'>Reference</a></strong> section contains the description of
-        every single configuration option, attribute, class, and element used in ReSpec. It is
+        every single configuration option, attribute, class, element, and event used in ReSpec. It is
         somewhat dry but aims at being objective. Six start and three thumbs up for bedtime reading.
       </p>
       <p>

--- a/src/ref.html
+++ b/src/ref.html
@@ -37,5 +37,10 @@
       <h2>Classes</h2>
       <!-- CLASSES -->
     </section>
+    
+    <section>
+      <h2>Events</h2>
+      <!-- EVENTS -->
+    </section>
   </body>
 </html>

--- a/src/ref.html
+++ b/src/ref.html
@@ -40,6 +40,9 @@
     
     <section>
       <h2>Events</h2>
+      <p>ReSpec has a general event publish / subscribe system.  Developers extending
+      the system can do so by subscribing to events they care about and performing actions
+      when those events are fired.  The interfaces and events are documented in this section.</p>
       <!-- EVENTS -->
     </section>
   </body>


### PR DESCRIPTION
This request adds documentation about the event mechanism.  It includes documentation on the new "save" respec event that is introduced in the ReSpec pull request 335 - so it should only be merged when/if that pull request is merged.

https://github.com/w3c/respec/pull/335
