### PR TITLE
Added description of processVersion

### DIFF
--- a/src/conf/processVersion.html
+++ b/src/conf/processVersion.html
@@ -1,0 +1,10 @@
+<section>
+  <h2>processVersion</h2>
+  <p>
+    ReSpec knows to include an indication of the W3C process under which the document
+    was developed.  This indication appears at the end of the Status of This Document
+    section.  By default it indicates the new "2014" process.  You can override this by
+    setting the processVersion configuration option to anything other than "2014".  The
+    previous process document, for example, was "2005".
+  </p>
+</section>


### PR DESCRIPTION
The new processVersion flag allows documents to reference the new
or old process.  This is in response to a private question
that @iherman sent me asking how to change the reference.
