### PR TITLE
Avoid mixed content in Respec's documentation.

### DIFF
--- a/examples/boilerplate.html
+++ b/examples/boilerplate.html
@@ -3,7 +3,7 @@
   <head>
     <title>Unicorns and Dahuts</title>
     <meta charset='utf-8'>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/examples/inlines.html
+++ b/examples/inlines.html
@@ -3,7 +3,7 @@
   <head>
     <title>Unicorns and Dahuts</title>
     <meta charset='utf-8'>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/examples/minimal-w3c.html
+++ b/examples/minimal-w3c.html
@@ -3,7 +3,7 @@
   <head>
     <title>Unicorns and Dahuts</title>
     <meta charset='utf-8'>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/examples/structure.html
+++ b/examples/structure.html
@@ -3,7 +3,7 @@
   <head>
     <title>Unicorns and Dahuts</title>
     <meta charset='utf-8'>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/examples/template.html
+++ b/examples/template.html
@@ -3,7 +3,7 @@
   <head>
     <title>This Is The Name Of Your Specification</title>
     <meta charset='utf-8'>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/examples/webidl-contiguous.html
+++ b/examples/webidl-contiguous.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'/>
     <title>WebIDL Tests</title>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/examples/webidl.html
+++ b/examples/webidl.html
@@ -3,7 +3,7 @@
   <head>
     <title>Unicorns and Dahuts</title>
     <meta charset='utf-8'>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {

--- a/guide.html
+++ b/guide.html
@@ -84,7 +84,7 @@
         <h2>Including ReSpec</h2>
         <p>
           You can see that the example above includes a script sourced at 
-          <code>http://www.w3.org/Tools/respec/respec-w3c-common</code>. That is the ReSpec 
+          <code>https://www.w3.org/Tools/respec/respec-w3c-common</code>. That is the ReSpec 
           profile for W3C specifications. If you look at examples in the wild you may on occasion
           find other links — but use this one. You may also be tempted to save the script to your
           local directory and use it from there. That may on occasion be useful (e.g. if you're on

--- a/ref.html
+++ b/ref.html
@@ -270,8 +270,8 @@
     <pre class='example highlight'>
 logos: [
    {
-      src: 'http://example.com/logo.gif',
-      href: "http://example.com",
+      src: 'https://example.com/logo.gif',
+      href: "https://example.com",
       alt: "example.com",
       width: 100,
       height: 42,
@@ -281,9 +281,9 @@ logos: [
     <p>This causes the standard logo to replaced with
 <pre class='example highlight'>
 &lt;p>
-  &lt;a href="http://example.com">
+  &lt;a href="https://example.com">
     &lt;span id="something">
-      &lt;img src="http://example.com/logo.gif" width='100' height='42' alt='example.com' />
+      &lt;img src="https://example.com/logo.gif" width='100' height='42' alt='example.com' />
     &lt;/span>
   &lt;/a>
 &lt;/p>

--- a/src/conf/logos.html
+++ b/src/conf/logos.html
@@ -11,8 +11,8 @@
     <pre class='example highlight'>
 logos: [
    {
-      src: 'http://example.com/logo.gif',
-      href: "http://example.com",
+      src: 'https://example.com/logo.gif',
+      href: "https://example.com",
       alt: "example.com",
       width: 100,
       height: 42,
@@ -22,9 +22,9 @@ logos: [
     <p>This causes the standard logo to replaced with
 <pre class='example highlight'>
 &lt;p>
-  &lt;a href="http://example.com">
+  &lt;a href="https://example.com">
     &lt;span id="something">
-      &lt;img src="http://example.com/logo.gif" width='100' height='42' alt='example.com' />
+      &lt;img src="https://example.com/logo.gif" width='100' height='42' alt='example.com' />
     &lt;/span>
   &lt;/a>
 &lt;/p>

--- a/src/guide.html
+++ b/src/guide.html
@@ -84,7 +84,7 @@
         <h2>Including ReSpec</h2>
         <p>
           You can see that the example above includes a script sourced at 
-          <code>http://www.w3.org/Tools/respec/respec-w3c-common</code>. That is the ReSpec 
+          <code>https://www.w3.org/Tools/respec/respec-w3c-common</code>. That is the ReSpec 
           profile for W3C specifications. If you look at examples in the wild you may on occasion
           find other links — but use this one. You may also be tempted to save the script to your
           local directory and use it from there. That may on occasion be useful (e.g. if you're on


### PR DESCRIPTION
Most of these are just the examples' `<script src>` tags, but src/conf/logos.html
also included an example of sourcing an image over HTTP.

You can see this broken now if you click the link from https://www.w3.org/respec/guide.html#contiguous-idl.
