### PR TITLE
Added an entry to document the usage of ``data-number``.

### DIFF
--- a/src/attrs/data-number.html
+++ b/src/attrs/data-number.html
@@ -1,5 +1,9 @@
 <section>
   <h2>data-number</h2>
   <p>
-    Used in conjunction with the configuration option <code>issueBase</code> and with a paragraph with class value <code>issue</code>. The issue number is added to the header of the paragraph, linked to the issue by concatenating the values of <code>issueBase</code> and <code>data-number</code>. Particularly useful when using github to link into the discussion thread of a particular issue.</p> 
+    Used in conjunction with the configuration option <code>issueBase</code> and with a paragraph with class value
+    <code>issue</code>. The issue number is added to the header of the paragraph, linked to the issue by
+    concatenating the values of <code>issueBase</code> and <code>data-number</code>. This is particularly useful 
+    when using github to link into the discussion thread of a particular issue.
+  </p>
 </section>

--- a/src/attrs/data-number.html
+++ b/src/attrs/data-number.html
@@ -1,12 +1,20 @@
 <section>
   <h2>data-number</h2>
   <p>
-    Used in conjunction with the configuration option <code>issueBase</code> and with a paragraph with class value
-    <code>issue</code>. The issue number is added to the header of the paragraph, linked to the issue by
-    concatenating the values of <code>issueBase</code> and <code>data-number</code>. This is particularly useful 
-    when using github to link into the discussion thread of a particular issue. A typical example for a file
-    in the github repository <code>https:/github.com/w3c/dpub-pwd</code> would include, for example:
+    Can be used in conjunction with the configuration option <code>issueBase</code> and with
+    a paragraph with class value <code>issue</code>. The issue number is added to
+    the header of the paragraph, and linked to the issue by concatenating the values
+    of <code>issueBase</code> and <code>data-number</code>. This is particularly
+    useful when using GitHub to link into the discussion thread of a particular issue.
+    A typical example for a file in the github repository <code>https:/github.com/w3c/dpub-pwd</code>
+    would include, for example:
   </p>
-  <pre><code>&lt;p class="issue" data-number="1"&gt;Change the terminology to "Portable Web Publication"&lt;\p&gt;</code></pre>
-  <p>If the configuration of the file includes <code>issueBase:"https:/github.com/w3c/dpub-pwd/issues"</code>, then the paragraph will be automatically entitled "ISSUE 1", with a link to the corresponding Github issue entry (and there is a built-in CSS style statement to set the background color of the paragram).</p>
+<pre><code>
+   &lt;p class="issue" data-number="1"&gt;Change the terminology to "Portable Web Publication"&lt;\p&gt;
+</code></pre>
+  <p>
+    If the configuration of the file includes <code>issueBase:"https:/github.com/w3c/dpub-pwd/issues"</code>,
+    then the paragraph will be automatically entitled "ISSUE 1", with a link to the
+    corresponding Github issue.
+  </p>
 </section>

--- a/src/attrs/data-number.html
+++ b/src/attrs/data-number.html
@@ -4,6 +4,9 @@
     Used in conjunction with the configuration option <code>issueBase</code> and with a paragraph with class value
     <code>issue</code>. The issue number is added to the header of the paragraph, linked to the issue by
     concatenating the values of <code>issueBase</code> and <code>data-number</code>. This is particularly useful 
-    when using github to link into the discussion thread of a particular issue.
+    when using github to link into the discussion thread of a particular issue. A typical example for a file
+    in the github repository <code>https:/github.com/w3c/dpub-pwd</code> would include, for example:
   </p>
+  <pre><code>&lt;p class="issue" data-number="1"&gt;Change the terminology to "Portable Web Publication"&lt;\p&gt;</code></pre>
+  <p>If the configuration of the file includes <code>issueBase:"https:/github.com/w3c/dpub-pwd/issues"</code>, then the paragraph will be automatically entitled "ISSUE 1", with a link to the corresponding Github issue entry (and there is a built-in CSS style statement to set the background color of the paragram).</p>
 </section>

--- a/src/attrs/data-number.html
+++ b/src/attrs/data-number.html
@@ -1,0 +1,5 @@
+<section>
+  <h2>data-number</h2>
+  <p>
+    Used in conjunction with the configuration option <code>issueBase</code> and with a paragraph with class value <code>issue</code>. The issue number is added to the header of the paragraph, linked to the issue by concatenating the values of <code>issueBase</code> and <code>data-number</code>. Particularly useful when using github to link into the discussion thread of a particular issue.</p> 
+</section>


### PR DESCRIPTION
I find the usage of `data-number` very useful when there lots of issues in github, but I did not see it documented. So here it is...

I am not sure how exactly the documentation generation works, ie, whether the name of the file has to be added somewhere, or all files in the `attrs` are automatically included. Would welcome help on that. 
