### PR TITLE
[WIP] Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "build": "node ./tools/build.js"
   },
   "dependencies": {
-    "respec": "^3.2",
     "async": "^1.5.0",
     "bootstrap": "git://github.com/twbs/bootstrap.git",
-    "less": "1.4.2",
+    "less": "^2.5.3",
+    "respec": "^3.2",
     "wrench": "^1.5.8"
   }
 }


### PR DESCRIPTION
&hellip;running [updtr](https://github.com/peerigon/updtr).

**Not ready yet.** I get this error with the new version of `less`:

```
$ nodejs tools/build.js 
[OK] Docs built
[OK] Beryl built
/home/tripu/t/repo/respec-docs/node_modules/less/lib/less/parser/parser.js:117
            imports.contents[fileInfo.filename] = str;
                   ^

TypeError: Cannot read property 'contents' of undefined
    at Object.Parser.parse (/home/tripu/t/repo/respec-docs/node_modules/less/lib/less/parser/parser.js:117:20)
    at buildBootstrap (/home/tripu/t/repo/respec-docs/tools/build.js:44:10)
    at /home/tripu/t/repo/respec-docs/node_modules/async/lib/async.js:713:13
    at Immediate.iterate [as _onImmediate] (/home/tripu/t/repo/respec-docs/node_modules/async/lib/async.js:262:13)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

[This might be the issue](https://github.com/gruntjs/grunt-contrib-less/issues/224), although updating Node.js and npm didn't help me anyway.

``` bash
$ nodejs -v
v4.2.2
$ npm -v
3.5.0
```
